### PR TITLE
config/Prepare server for aws lambda execution

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
 	"description": "A custom Flickr UI using the public feed Flickr API",
 	"main": "dist/index.html",
 	"scripts": {
-		"build": "webpack --config webpack/webpack.config.js",
+		"build": "cross-env NODE_ENV=production webpack --config webpack/webpack.config.js",
 		"preview": "cross-env NODE_ENV=development PORT=8000 webpack-dev-server --config webpack/webpack.config.js",
 		"storybook": "start-storybook -p 8800",
 		"test": "npm run unit-test",

--- a/frontend/src/app/Configs/Endpoints.ts
+++ b/frontend/src/app/Configs/Endpoints.ts
@@ -11,7 +11,7 @@ export const SERVER_URL: ISERVER_URL = {
 		https: `http://localhost:${process.env.HTTPS_PORT || 8881}`
 	},
 	production: {
-		http: `http://localhost:${process.env.HTTP_PORT || 8880}`,
-		https: `http://localhost:${process.env.HTTPS_PORT || 8881}`
+		http: `https://l918iu7upb.execute-api.ap-southeast-2.amazonaws.com/production/Flickr_Feed_Proxy/`,
+		https: `https://l918iu7upb.execute-api.ap-southeast-2.amazonaws.com/production/Flickr_Feed_Proxy/`
 	}
 };

--- a/server/package.json
+++ b/server/package.json
@@ -14,6 +14,7 @@
 	"author": "dropbeardan",
 	"license": "MIT",
 	"devDependencies": {
+		"@types/aws-serverless-express": "^3.3.0",
 		"@types/axios": "^0.14.0",
 		"@types/cors": "^2.8.4",
 		"@types/express": "^4.16.1",
@@ -24,6 +25,7 @@
 		"typescript": "^3.4.4"
 	},
 	"dependencies": {
+		"aws-serverless-express": "^3.3.6",
 		"axios": "^0.18.0",
 		"body-parser": "^1.18.3",
 		"cors": "^2.8.5",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -8,7 +8,7 @@ import { JSONBodySyntaxErrorHandler } from './middlewares';
 
 import { routes } from './routes';
 
-const app = express();
+export const app = express();
 
 app.use(cors());
 app.use(bodyParser.json());
@@ -17,16 +17,18 @@ app.use(JSONBodySyntaxErrorHandler);
 
 app.all('*', routes);
 
-const httpPort = process.env.HTTP_PORT || 8880;
-const httpsPort = process.env.HTTPS_PORT || 8881;
+if (process.env.MODE !== 'AWS_LAMBDA') {
+	const httpPort = process.env.HTTP_PORT || 8880;
+	const httpsPort = process.env.HTTPS_PORT || 8881;
 
-http
-	.createServer(app)
-	.listen(httpPort, () =>
-		console.log(`Listening to HTTP requests on port ${httpPort}.`)
-	);
-https
-	.createServer(app)
-	.listen(httpsPort, () =>
-		console.log(`Listening to HTTP requests on port ${httpsPort}.`)
-	);
+	http
+		.createServer(app)
+		.listen(httpPort, () =>
+			console.log(`Listening to HTTP requests on port ${httpPort}.`)
+		);
+	https
+		.createServer(app)
+		.listen(httpsPort, () =>
+			console.log(`Listening to HTTP requests on port ${httpsPort}.`)
+		);
+}

--- a/server/src/serverless.ts
+++ b/server/src/serverless.ts
@@ -1,0 +1,8 @@
+import * as AWSServerlessExpress from 'aws-serverless-express';
+
+import { app } from './index';
+
+const server = AWSServerlessExpress.createServer(app);
+
+export const handler = (event: any, context: any) =>
+	AWSServerlessExpress.proxy(server, event, context);

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -283,6 +283,20 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/yargs" "^12.0.9"
 
+"@types/aws-lambda@*":
+  version "8.10.24"
+  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.24.tgz#89a20cd91957322e26dbfea7f651b970460c8c0c"
+  integrity sha512-9F70bcb2oBGZUZCyisE1Ap3vwgt04uiSmr4s9mhQf89vBrttgraBs2Rc8l9YrKiemCndCH7wxnYNWk5qEuv6rA==
+
+"@types/aws-serverless-express@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@types/aws-serverless-express/-/aws-serverless-express-3.3.0.tgz#bd38ff4148a39ca1824def185655cae9695de9ba"
+  integrity sha512-pGaTXVKtevSraTtPMP58ReJFvW9w9S3ValgdIZFghNinzIwMUvS18qqdTrnLjRDUQmUww9nVHb+7vGVSOAOyLw==
+  dependencies:
+    "@types/aws-lambda" "*"
+    "@types/express" "*"
+    "@types/node" "*"
+
 "@types/axios@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@types/axios/-/axios-0.14.0.tgz#ec2300fbe7d7dddd7eb9d3abf87999964cafce46"
@@ -599,6 +613,14 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
+aws-serverless-express@^3.3.6:
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/aws-serverless-express/-/aws-serverless-express-3.3.6.tgz#5fb35c23af3d6e18a6bebdb4397d20dfdcc0a828"
+  integrity sha512-VTn8YQpPpMAEdMeGjyaSygy7Rc0057C9MUjeZION0NBqmwTyphpu9Tc5DCHRNF4qNFQ9x1xcOte6OXKzJvvDhw==
+  dependencies:
+    binary-case "^1.0.0"
+    type-is "^1.6.16"
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -678,6 +700,11 @@ bcrypt-pbkdf@^1.0.0:
   integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   dependencies:
     tweetnacl "^0.14.3"
+
+binary-case@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/binary-case/-/binary-case-1.1.4.tgz#d687104d59e38f2b9e658d3a58936963c59ab931"
+  integrity sha512-9Kq8m6NZTAgy05Ryuh7U3Qc4/ujLQU1AZ5vMw4cr3igTdi5itZC6kCNrRr2X8NzPiDn2oUIFTfa71DKMnue/Zg==
 
 body-parser@1.18.3, body-parser@^1.18.3:
   version "1.18.3"
@@ -3812,7 +3839,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-is@~1.6.16:
+type-is@^1.6.16, type-is@~1.6.16:
   version "1.6.16"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.16.tgz#f89ce341541c672b25ee7ae3c73dee3b2be50194"
   integrity sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==


### PR DESCRIPTION
Changes:
- Added aws-serverless-express to act as a proxy for AWS Lambda entry point [serverless.js : handler()]
- Masked HTTP and HTTPs port reservation to non AWS Lambda modes
- Created new AWS Lambda endpoint and added endpoint address as SERVER_URL production value